### PR TITLE
Fix Pong scoreboard alignment

### DIFF
--- a/Projects/Pong/scoreboard.py
+++ b/Projects/Pong/scoreboard.py
@@ -1,6 +1,6 @@
 from turtle import Turtle
 
-ALIGN = "Center"
+ALIGN = "center"
 FONT = ("Arial", 20, "normal")
 
 

--- a/tests/test_pong_scoreboard.py
+++ b/tests/test_pong_scoreboard.py
@@ -1,0 +1,34 @@
+from unittest import mock
+import importlib
+
+# Dummy Turtle class
+class DummyTurtle:
+    def __init__(self):
+        pass
+    def color(self, *args, **kwargs):
+        pass
+    def penup(self):
+        pass
+    def hideturtle(self):
+        pass
+    def goto(self, *args, **kwargs):
+        pass
+    def write(self, *args, **kwargs):
+        pass
+    def seth(self, *args, **kwargs):
+        pass
+    def ycor(self):
+        return -400
+    def pendown(self):
+        pass
+    def forward(self, *args, **kwargs):
+        pass
+    def clear(self):
+        pass
+
+def test_scoreboard_updates_without_error():
+    with mock.patch('turtle.Turtle', DummyTurtle):
+        sb_module = importlib.import_module('Projects.Pong.scoreboard')
+        sb = sb_module.Scoreboard()
+        sb.update_left()
+        sb.update_right()


### PR DESCRIPTION
## Summary
- fix scoreboard alignment constant to lowercase
- add a test to ensure scoreboard updates run without errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447279cfbc8321817889e1b5fd7d45